### PR TITLE
Update CLAUDE.md docs to reflect current codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,9 @@ Turborepo + pnpm monorepo · Hono + tRPC API · TanStack Start (React 19) fronte
 | Workspace | Package | Description |
 |-----------|---------|-------------|
 | `apps/admin` | `@puckhub/admin` | TanStack Start admin UI (port 3000), i18n (DE/EN) |
-| `apps/web` | — | Public website (placeholder) |
-| `packages/api` | `@puckhub/api` | Hono server + tRPC (22 routers) + Better Auth (port 3001) |
-| `packages/db` | `@puckhub/db` | Drizzle schema (32 files, 10 enums), migrations, seeds |
+| `apps/web` | `@puckhub/web` | Public website (placeholder) |
+| `packages/api` | `@puckhub/api` | Hono server + tRPC (24 routers) + Better Auth (port 3001) |
+| `packages/db` | `@puckhub/db` | Drizzle schema (34 files, 10 enums), migrations, seeds, services |
 | `packages/ui` | `@puckhub/ui` | Shared UI components (Button, Card, Dialog, Badge, etc.) |
 | `packages/config` | `@puckhub/config` | Minimal — runtime config lives in DB `system_settings` table |
 
@@ -23,18 +23,24 @@ Turborepo + pnpm monorepo · Hono + tRPC API · TanStack Start (React 19) fronte
 pnpm dev                # Start Docker (DB + pgAdmin) + all dev servers (admin :3000, api :3001)
 pnpm build              # Build all packages and apps
 pnpm test               # Run all tests (Vitest)
+pnpm test:api           # Run API tests only
+pnpm test:e2e           # Run Playwright E2E tests (admin app)
 pnpm lint               # TypeScript type-check across all packages
+pnpm format             # Format all files with Biome
+pnpm format:check       # Check formatting without writing
+pnpm check              # Biome check + auto-fix
+pnpm check:ci           # Biome CI check (no auto-fix)
 pnpm db:generate        # Generate Drizzle migrations after schema changes
-pnpm db:seed:demo       # Seed demo data (10 teams, 100 players, 10 seasons)
-pnpm docker:up          # Start Docker containers only
-pnpm docker:down        # Stop Docker containers
+pnpm db:init-demo       # Seed demo data (10 teams, 100 players, 16 seasons)
+pnpm db:reset           # Reset database (truncate all tables)
+pnpm dev:docker:up      # Start Docker containers only
+pnpm dev:docker:down    # Stop Docker containers
 ```
 
 **Per-package** (run from package dir or with `pnpm --filter`):
 - `db:migrate` — push schema (dev) · `db:migrate:prod` — run migrations (prod)
 - `db:studio` — Drizzle Studio visual editor
-- `db:seed` — seed reference data only (penalty types, trikot templates)
-- `test:e2e` — Playwright E2E tests (admin app)
+- `db:seed` — seed reference data only (penalty types, trikot templates, static pages)
 
 ## Environment
 
@@ -49,6 +55,14 @@ Copy `.env.example` to `.env`. Key variables:
 | `ADMIN_PORT` | `3000` | Admin dev server port |
 | `AUTO_MIGRATE` | `true` | Auto-run migrations on API startup |
 | `UPLOAD_DIR` | `./uploads` | File upload directory |
+| `PASSKEY_RP_ID` | `localhost` | WebAuthn relying party ID |
+| `PASSKEY_RP_NAME` | `PuckHub Admin` | WebAuthn relying party name |
+| `PASSKEY_ORIGIN` | `http://localhost:3000` | WebAuthn origin |
+
+## Docker
+
+- **Development**: `docker/docker-compose.yml` — PostgreSQL 16 + pgAdmin (port 5050)
+- **Production**: `docker-compose.prod.yml` — PostgreSQL 16 + API container (multi-stage `Dockerfile`)
 
 ## Conventions
 
@@ -59,6 +73,7 @@ Copy `.env.example` to `.env`. Key variables:
 - **Package manager**: pnpm 10.28.2 — always use `pnpm`, never npm/yarn
 - **TypeScript**: Strict mode, `noUncheckedIndexedAccess`, ES2022 target
 - **Path aliases**: `~/` = `src/`, `@/` = `lib/` (admin app only)
+- **Formatter/Linter**: Biome (2-space indent, 120-char line width, single quotes JS, double quotes JSX)
 
 ## Package-Level Docs
 

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -12,6 +12,7 @@ src/routes/
 └── _authed.tsx             # Protected layout (sidebar, session check, season context)
     ├── index.tsx           # Dashboard
     ├── settings.tsx        # League settings
+    ├── security.tsx        # Security settings (passkey, 2FA)
     ├── standings.tsx       # Standings view
     ├── stats.tsx           # Statistics
     ├── games/index.tsx     # Games calendar + scheduling
@@ -61,9 +62,9 @@ import { useTranslation } from '~/i18n/use-translation'
 ```
 src/i18n/
 ├── locales/
-│   ├── de-DE/common.json   # German translations (~1300 lines)
+│   ├── de-DE/common.json   # German translations
 │   ├── de-DE/errors.json   # German error messages
-│   ├── en-US/common.json   # English translations (~1300 lines)
+│   ├── en-US/common.json   # English translations
 │   └── en-US/errors.json   # English error messages
 ├── resources.ts             # Resource imports & locale normalization
 ├── locale-context.tsx       # LocaleProvider context, useLocale() hook
@@ -76,15 +77,14 @@ src/i18n/
 - **Namespaces**: `common` (all UI text), `errors` (error messages)
 - User locale preference stored in DB and synced via `localeSync.tsx` component
 
-## Component Organization (~65 files)
+## Component Organization (~89 files)
 
 ```
 src/components/
-├── gettingStarted/        # Setup wizard
-│   ├── gettingStartedWizard.tsx
-│   ├── wizardLayout.tsx
-│   ├── stepIndicator.tsx
-│   └── steps/             # welcomeStep, leagueOverviewStep, adminAccountStep, firstSeasonStep, completeStep
+├── auth/                  # Authentication components
+│   ├── loginForm.tsx
+│   ├── passkeyButton.tsx
+│   └── twoFactorForm.tsx
 ├── gameReport/            # Game report editing (10 components)
 │   ├── gameReportHeader.tsx
 │   ├── gameTimeline.tsx   # Chronological event timeline
@@ -96,58 +96,94 @@ src/components/
 │   ├── lineupEditor.tsx   # Manage game lineups
 │   ├── teamRosterChecklist.tsx  # Player checklist for lineup
 │   └── timelineEvent.tsx  # Single event in timeline
-├── structureBuilder/      # React Flow canvas for season structure
+├── gettingStarted/        # Setup wizard (8 files)
+│   ├── gettingStartedWizard.tsx
+│   ├── wizardLayout.tsx
+│   ├── stepIndicator.tsx
+│   └── steps/             # welcomeStep, leagueOverviewStep, adminAccountStep, firstSeasonStep, completeStep
+├── playerTimeline/        # Player history timeline (playerTimeline.tsx)
+├── roster/                # Roster management (4 files)
+│   ├── rosterTable.tsx
+│   ├── signPlayerDialog.tsx
+│   ├── editContractDialog.tsx
+│   └── transferDialog.tsx
+├── security/              # Security settings (2 files)
+│   ├── passkeySection.tsx
+│   └── twoFactorSection.tsx
+├── skeletons/             # Loading skeleton components (3 files)
+│   ├── countSkeleton.tsx
+│   ├── dataListSkeleton.tsx
+│   └── filterPillsSkeleton.tsx
+├── standings/             # Standings components (3 files)
+│   ├── standingsTable.tsx
+│   ├── bonusPointsSection.tsx
+│   └── bonusPointsDialog.tsx
+├── stats/                 # Statistics & charts (15 files)
+│   ├── statsSummaryCards.tsx
+│   ├── statsTabNavigation.tsx
+│   ├── statsRoundInfo.tsx
+│   ├── scorerTable.tsx
+│   ├── scorerChart.tsx
+│   ├── goalieTable.tsx
+│   ├── goalieChart.tsx
+│   ├── penaltyPlayerTable.tsx
+│   ├── penaltyTeamChart.tsx
+│   ├── penaltyTypeChart.tsx
+│   ├── teamStandingsTable.tsx
+│   ├── teamComparisonSelector.tsx
+│   ├── teamComparisonBar.tsx
+│   ├── teamComparisonRadar.tsx
+│   └── echartsWrapper.tsx
+├── structureBuilder/      # React Flow canvas for season structure (15 files)
 │   ├── structureCanvas.tsx
 │   ├── setupWizardDialog.tsx
 │   ├── nodes/             # Custom node types (seasonNode, divisionNode, roundNode, teamNode)
 │   ├── panels/            # sidePanel, divisionEditPanel, roundEditPanel, teamAssignmentPanel, teamPalette
 │   └── utils/             # layout, nodeFactory, roundTypeColors, roundTypeIcons
-├── playerTimeline/        # Player history timeline (playerTimeline.tsx)
-├── roster/                # Roster management (rosterTable, signPlayerDialog, editContractDialog, transferDialog)
-├── skeletons/             # Loading skeleton components
-│   ├── countSkeleton.tsx
-│   ├── dataListSkeleton.tsx
-│   └── filterPillsSkeleton.tsx
-├── playerCombobox.tsx     # Player search/select combobox
-├── teamCombobox.tsx       # Team search/select combobox
-├── teamFilterPills.tsx    # Team filter pill badges
-├── dataPageLayout.tsx     # Standard data page layout wrapper
-├── pageHeader.tsx         # Reusable page header
-├── emptyState.tsx         # Empty state placeholder
-├── noResults.tsx          # No search results state
 ├── confirmDialog.tsx      # Confirmation modal
-├── searchInput.tsx        # Search input
+├── dataPageLayout.tsx     # Standard data page layout wrapper
+├── emptyState.tsx         # Empty state placeholder
 ├── filterPill.tsx         # Filter pill component
+├── gameStatusBadge.tsx    # Game status badge
+├── hoverCard.tsx          # Generic hover card
 ├── imageUpload.tsx        # Image upload (logo/photo)
+├── languagePicker.tsx     # Language picker (DE/EN)
+├── localeSync.tsx         # Locale synchronization
+├── newsForm.tsx           # News article form
+├── noResults.tsx          # No search results state
+├── pageForm.tsx           # Page content form
+├── pageHeader.tsx         # Reusable page header
+├── pageSkeleton.tsx       # Full-page loading skeleton
+├── playerCombobox.tsx     # Player search/select combobox
+├── playerHoverCard.tsx    # Player hover card
 ├── richTextEditor.tsx     # Rich text editor (Tiptap)
 ├── richTextEditorLazy.tsx # Lazy-loaded rich text editor
-├── pageSkeleton.tsx       # Full-page loading skeleton
-├── trikotPreview.tsx      # Jersey preview
-├── teamHoverCard.tsx      # Team hover card
-├── playerHoverCard.tsx    # Player hover card
-├── hoverCard.tsx          # Generic hover card
-├── gameStatusBadge.tsx    # Game status badge
+├── searchInput.tsx        # Search input
 ├── seasonIndicator.tsx    # Season indicator badge
 ├── seasonPickerModal.tsx  # Season selection modal
-├── localeSync.tsx         # Locale synchronization
-├── languagePicker.tsx     # Language picker (DE/EN)
-├── newsForm.tsx           # News article form
-└── pageForm.tsx           # Page content form
+├── teamCombobox.tsx       # Team search/select combobox
+├── teamFilterPills.tsx    # Team filter pill badges
+├── teamHoverCard.tsx      # Team hover card
+└── trikotPreview.tsx      # Jersey preview
 ```
 
 ## Contexts
 
 ```
 src/contexts/
-└── season-context.tsx     # Current season selection (used in _authed.tsx layout)
+└── seasonContext.tsx      # Current season selection (used in _authed.tsx layout)
 ```
 
 ## Lib
 
 ```
-src/lib/
-├── errorI18n.ts        # Error code to i18n key mapping
-└── search-params.ts    # FILTER_ALL constant for URL-based filtering
+lib/                       # @/ alias target (at app root, outside src/)
+├── auth-client.ts         # Better Auth React client configuration
+└── trpc.ts                # tRPC React Query client configuration
+
+src/lib/                   # Inside src/
+├── errorI18n.ts           # Error code to i18n key mapping
+└── search-params.ts       # FILTER_ALL constant for URL-based filtering
 ```
 
 ## State Management
@@ -161,7 +197,8 @@ src/lib/
 ## E2E Testing
 
 - **Framework**: Playwright (Chromium only)
-- **Test dir**: `e2e/`
+- **Test dir**: `e2e/` (4 spec files + 3 infrastructure files)
+- **Specs**: `auth.spec.ts`, `players.spec.ts`, `teams.spec.ts`, `trikots.spec.ts`
 - **Ports**: Admin on 4000, API on 4001 (separate from dev)
-- **Isolation**: `globalSetup` / `globalTeardown` handle test DB via testcontainers
+- **Isolation**: `global-setup.ts` / `global-teardown.ts` handle test DB via testcontainers
 - **Run**: `pnpm test:e2e`

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -1,22 +1,22 @@
 # @puckhub/db
 
-Drizzle ORM with PostgreSQL. Schema definitions, migrations, and seed data.
+Drizzle ORM with PostgreSQL. Schema definitions, migrations, seeds, and services.
 
-## Schema Organization (32 files in `src/schema/`)
+## Schema Organization (34 files in `src/schema/`)
 
-**Auth**: `auth.ts` (user, session, account, verification)
-**Core**: `seasons.ts` · `divisions.ts` · `rounds.ts` · `teams.ts` · `team-divisions.ts` · `venues.ts`
+**Auth**: `auth.ts` (user, session, account, verification) · `passkey.ts` · `twoFactor.ts`
+**Core**: `seasons.ts` · `divisions.ts` · `rounds.ts` · `teams.ts` · `teamDivisions.ts` · `venues.ts`
 **Players**: `players.ts` · `contracts.ts` (player-team-season links)
-**Games**: `games.ts` · `game-events.ts` (goals/penalties) · `game-lineups.ts` (player participation) · `game-suspensions.ts` (multi-game suspensions) · `penalty-types.ts`
-**Stats**: `standings.ts` · `bonus-points.ts` · `player-season-stats.ts` · `goalie-season-stats.ts` · `goalie-game-stats.ts`
-**Trikots**: `trikot-templates.ts` · `trikots.ts` · `team-trikots.ts`
-**Content**: `news.ts` · `pages.ts` (CMS pages with menu locations) · `page-aliases.ts` · `documents.ts` · `sponsors.ts`
-**System**: `user-roles.ts` · `system-settings.ts`
-**Shared**: `enums.ts` · `relations.ts` · `index.ts` (re-exports all)
+**Games**: `games.ts` · `gameEvents.ts` (goals/penalties) · `gameLineups.ts` (player participation) · `gameSuspensions.ts` (multi-game suspensions) · `penaltyTypes.ts`
+**Stats**: `standings.ts` · `bonusPoints.ts` · `playerSeasonStats.ts` · `goalieSeasonStats.ts` · `goalieGameStats.ts`
+**Trikots**: `trikotTemplates.ts` · `trikots.ts` · `teamTrikots.ts`
+**Content**: `news.ts` · `pages.ts` (CMS pages with menu locations) · `pageAliases.ts` · `documents.ts` · `sponsors.ts`
+**System**: `userRoles.ts` · `systemSettings.ts`
+**Shared**: `enums.ts` · `relations.ts` (287 lines, 27 relation definitions) · `index.ts` (re-exports all)
 
 ## Enums (`src/schema/enums.ts`) — 10 enums
 
-- `roundTypeEnum`: regular, preround, playoffs, playdowns, relegation, placement, final
+- `roundTypeEnum`: regular, preround, playoffs, playdowns, playups, relegation, placement, final
 - `positionEnum`: forward, defense, goalie
 - `gameStatusEnum`: scheduled, in_progress, completed, postponed, cancelled
 - `gameEventTypeEnum`: goal, penalty
@@ -33,7 +33,16 @@ Drizzle ORM with PostgreSQL. Schema definitions, migrations, and seed data.
 - **Cascade rules**: Foreign keys use `onDelete: 'cascade'` or `onDelete: 'set null'` as appropriate
 - **Singleton**: `system_settings` uses `check(eq(id, 1))` constraint
 - **Self-joins**: Use `aliasedTable()` from `drizzle-orm/alias` — never use `sql` template as join target
-- **Relations**: All defined in `relations.ts` (~190 lines), required for `db.query.*.findMany({ with: {} })`
+- **Relations**: All defined in `relations.ts` (287 lines), required for `db.query.*.findMany({ with: {} })`
+
+## Services (`src/services/`)
+
+| Service | Purpose |
+|---------|---------|
+| `standingsService.ts` | Recalculate standings from game results, bonus points |
+| `statsService.ts` | Recalculate player and goalie statistics |
+
+Exports: `recalculateStandings`, `recalculatePlayerStats`, `recalculateGoalieStats`
 
 ## Migration Workflow
 
@@ -44,13 +53,15 @@ pnpm db:migrate           # Push to dev DB (drizzle-kit push)
 pnpm db:migrate:prod      # Run migrations (drizzle-kit migrate)
 ```
 
-Migrations are in `drizzle/` (4 migration files) with journal tracking. Auto-migrate on API startup when `AUTO_MIGRATE=true`.
+Migrations are in `drizzle/` (6 migration files) with journal tracking. Auto-migrate on API startup when `AUTO_MIGRATE=true`.
 
 ## Seed System
 
-- `src/seed/index.ts` — **Reference data**: penalty types (6), trikot templates (2). Safe to re-run (`onConflictDoNothing`)
+- `src/seed/index.ts` — **Reference data**: penalty types (6), trikot templates (2), static pages (3: Impressum, Datenschutz, Kontakt). Safe to re-run (`onConflictDoNothing`)
 - `src/seed/demo.ts` — **Demo data**: 10 teams, 100 players, 16 seasons (15 past + 1 current), venues, contracts, game reports (lineups/events/suspensions), news, sponsors, pages, admin user (`admin@demo.local` / `demo1234`). Truncates all tables first
 - `src/seed/run.ts` — Entry point for reference seed
+- `src/seed/reset.ts` — Database reset utility (truncates all tables with CASCADE, interactive prompt unless `--force`)
+- `src/seed/seedImages.ts` — Image generation utilities for seed data
 
 ## Adding a New Table
 
@@ -64,4 +75,5 @@ Migrations are in `drizzle/` (4 migration files) with journal tracking. Auto-mig
 ```ts
 import { db, schema, runMigrations, runSeed } from '@puckhub/db'
 import { seasons, teams, ... } from '@puckhub/db/schema'
+import { recalculateStandings, recalculatePlayerStats, recalculateGoalieStats } from '@puckhub/db/services'
 ```


### PR DESCRIPTION
- Root: Fix script names (db:init-demo, dev:docker:up/down), add missing
  scripts (test:api, format, check), update counts (24 routers, 34 schema
  files), add passkey env vars, document Docker setup
- Admin: Add security route, auth/security/standings/stats component dirs,
  update component count (~65 → ~89), fix context/lib paths, detail E2E specs
- API: Update router count (22 → 24, add dashboard + bonusPoints), fix
  services (only schedulerService remains), add errors/ dir, document
  passkey + 2FA auth, update test structure
- DB: Update schema count (32 → 34, add passkey + twoFactor), fix file
  names to camelCase, add playups enum value, update migration count
  (4 → 6), add services section, document reset + seedImages scripts

https://claude.ai/code/session_01AWSDQsGkUGm9hu7HfLTqYh