### PR TITLE
Fix admin mobile responsiveness: prevent horizontal overflow

### DIFF
--- a/apps/admin/src/routes/_authed/$orgSlug.tsx
+++ b/apps/admin/src/routes/_authed/$orgSlug.tsx
@@ -526,9 +526,9 @@ function SidebarLayout({ orgSlug }: { orgSlug: string }) {
       </aside>
 
       {/* --- Main content --- */}
-      <main className="flex-1 min-h-screen flex flex-col lg:ml-[260px]" style={{ background: "var(--content-bg)" }}>
+      <main className="flex-1 min-w-0 min-h-screen flex flex-col lg:ml-[260px]" style={{ background: "var(--content-bg)" }}>
         <TopBar />
-        <div className="content-enter flex-1 px-4 py-4 sm:px-6 lg:px-11 lg:py-6">
+        <div className="content-enter flex-1 px-4 py-4 sm:px-6 lg:px-11 lg:py-6 min-w-0">
           <Suspense fallback={<PageSkeleton />}>
             <Outlet />
           </Suspense>

--- a/apps/admin/src/routes/_authed/$orgSlug/news/index.tsx
+++ b/apps/admin/src/routes/_authed/$orgSlug/news/index.tsx
@@ -187,8 +187,8 @@ function NewsPage() {
 
                 {/* Content */}
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h3 className="font-semibold truncate">{article.title}</h3>
+                  <div className="flex items-center gap-2 min-w-0">
+                    <h3 className="font-semibold truncate min-w-0">{article.title}</h3>
                     {isScheduled ? (
                       <Badge variant="accent" className="shrink-0 text-[10px]">
                         <Clock className="mr-1 h-3 w-3" aria-hidden="true" />
@@ -203,19 +203,19 @@ function NewsPage() {
                   {article.shortText && (
                     <p className="text-sm text-muted-foreground truncate mt-0.5">{article.shortText}</p>
                   )}
-                  <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1.5 text-xs text-muted-foreground">
                     {article.author && <span>{article.author.name}</span>}
-                    <span className="text-border">|</span>
+                    <span className="text-border hidden sm:inline">|</span>
                     <span>{t("newsPage.meta.createdAt", { date: formatDate(article.createdAt) })}</span>
                     {article.publishedAt && (
                       <>
-                        <span className="text-border">|</span>
+                        <span className="text-border hidden sm:inline">|</span>
                         <span>{t("newsPage.meta.publishedAt", { date: formatDate(article.publishedAt) })}</span>
                       </>
                     )}
                     {isScheduled && (
                       <>
-                        <span className="text-border">|</span>
+                        <span className="text-border hidden sm:inline">|</span>
                         <span style={{ color: "hsl(var(--accent-foreground))" }}>
                           {t("newsPage.meta.scheduledFor", {
                             date: formatDate(article.scheduledPublishAt),


### PR DESCRIPTION
- Add min-w-0 to <main> flex item so it can shrink below content width
  in the root flex-row layout (fixes default min-width:auto behavior)
- Add min-w-0 to content wrapper div to pass width constraint through
  the flex-col chain to page content
- Fix news page metadata row: use flex-wrap for dates/author info on mobile
  and hide pipe separators on small screens for cleaner layout
- Add min-w-0 to news title container for proper truncation of long titles

https://claude.ai/code/session_01QR45yruhHn8uMXKt2pGw4S