### PR TITLE
feat: add API test job to CI pipeline with skip mechanisms

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,8 +34,6 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'skip-tests') ||
         contains(github.event.head_commit.message, '[skip tests]')
       )
-    env:
-      DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,6 +49,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
 
       - name: Run API tests
         run: pnpm test:api


### PR DESCRIPTION
Add a Vitest test job (with Testcontainers PostgreSQL) that runs before
Docker builds. Tests can be skipped via:
- workflow_dispatch checkbox in GitHub UI
- PR label "skip-tests"
- commit message containing [skip tests]

https://claude.ai/code/session_01UfxkHKZF2CmVLQUq431NJk